### PR TITLE
update deploy git ignore and the src build job cache

### DIFF
--- a/lib/deploy-site.gitignore
+++ b/lib/deploy-site.gitignore
@@ -41,6 +41,11 @@
 .svn
 gulpfile*
 
+# Node Dependency Files
+/node_modules/
+auth.json
+yarn-error.log
+
 # Known large file types
 *.sql
 *.hqx

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -23,7 +23,7 @@ steps:
 
     - restore_cache:
           keys:
-              - npm-{{ .Environment.CACHE_VERSION }}-{{ checksum "package-lock.json" }}
+              - npm-{{ .Environment.CACHE_VERSION }}-{{ checksum "${THEME_PATH}/package-lock.json" }}
     - run:
           name: Install node dependencies
           command: |
@@ -33,7 +33,7 @@ steps:
     - save_cache:
           paths:
               - ./node_modules
-          key: npm-{{ .Environment.CACHE_VERSION }}-{{ checksum "package-lock.json" }}
+          key: npm-{{ .Environment.CACHE_VERSION }}-{{ checksum "${THEME_PATH}/package-lock.json" }}
     - run:
           name: Build compiled files
           command: |


### PR DESCRIPTION
Updates the deployment gitignore to ignore theme node_modules and sets up npm cache paths.